### PR TITLE
URL typo

### DIFF
--- a/notebooks/Download Data.ipynb
+++ b/notebooks/Download Data.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "source": [
     "## Downloading Data using Public HTTP API\n",
-    "Te users can download data without authentication directly using HTTP address. The dataset's public URL is `ttps://storage.googleapis.com/objectron`. You can use curl, request or any other downloader for this purpose.\n"
+    "Te users can download data without authentication directly using HTTP address. The dataset's public URL is `https://storage.googleapis.com/objectron`. You can use curl, request or any other downloader for this purpose.\n"
    ]
   },
   {

--- a/notebooks/Download Data.ipynb
+++ b/notebooks/Download Data.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "source": [
     "## Downloading Data using Public HTTP API\n",
-    "Te users can download data without authentication directly using HTTP address. The dataset's public URL is `https://storage.googleapis.com/objectron`. You can use curl, request or any other downloader for this purpose.\n"
+    "The users can download data without authentication directly using HTTP address. The dataset's public URL is `https://storage.googleapis.com/objectron`. You can use curl, request or any other downloader for this purpose.\n"
    ]
   },
   {


### PR DESCRIPTION
The dataset's public URL is missing 'h'.